### PR TITLE
Fix for TypeError: Main.on_close() takes 2 positional arguments but 3…

### DIFF
--- a/usr/share/sofirem/GUI.py
+++ b/usr/share/sofirem/GUI.py
@@ -186,7 +186,7 @@ def GUI(self, Gtk, Gdk, GdkPixbuf, base_dir, os, Pango):  # noqa
         # =====================================================
         btnQuitSofi = Gtk.Button(label="Quit")
         btnQuitSofi.set_size_request(100, 30)
-        btnQuitSofi.connect("clicked", self.on_close)
+        btnQuitSofi.connect("clicked", self.on_close, "delete-event")
 
         # =====================================================
         #                      PACKS

--- a/usr/share/sofirem/sofirem.py
+++ b/usr/share/sofirem/sofirem.py
@@ -149,7 +149,7 @@ class Main(Gtk.Window):
     #               RESTART/QUIT BUTTON
     # =====================================================
 
-    def on_close(self, widget):
+    def on_close(self, widget, data):
         os.unlink("/tmp/sofirem.lock")
         os.unlink("/tmp/sofirem.pid")
 


### PR DESCRIPTION
Fennec: This error is shown in the terminal when a user closes the app using the close X button.
Issue. If a user launches the app without the terminal, the app stays running in the background.
This causes the lock file/pid file to remain inside /tmp.