### PR TITLE
Bug Fixes #2

### DIFF
--- a/usr/share/sofirem/Functions.py
+++ b/usr/share/sofirem/Functions.py
@@ -188,12 +188,36 @@ def install(self):
     pkg, signal, widget = self.pkg_queue.get()
     install_state = {}
     install_state[pkg] = "QUEUED"
+    thread_alive = False
+    lockfile_thread = "thread_waitForPacmanLockFile"
 
-    th = Thread(
-        target=waitForPacmanLockFile,
-    )
+    # check the pacman lock file thread isn't already running
+    for thread in threading.enumerate():
+        if thread.name == lockfile_thread and thread.is_alive():
+            thread_alive = True
+            break
 
-    th.start()
+    if thread_alive == False:
+        print(
+            "[DEBUG] %s Starting waitForPacmanLockFile thread."
+            % datetime.now().strftime("%H:%M:%S")
+        )
+        th = Thread(
+            name=lockfile_thread,
+            target=waitForPacmanLockFile,
+        )
+
+        th.start()
+    else:
+        print(
+            "[DEBUG] %s waitForPacmanLockFile thread is already running."
+            % datetime.now().strftime("%H:%M:%S")
+        )
+
+        print(
+            "[INFO] %s Another Package install is in progress."
+            % datetime.now().strftime("%H:%M:%S")
+        )
 
     try:
         print(

--- a/usr/share/sofirem/sofirem.py
+++ b/usr/share/sofirem/sofirem.py
@@ -435,14 +435,6 @@ class Main(Gtk.Window):
 
                 if len(self.pkg_inst_deque) <= 5:
                     self.pkg_inst_deque.append(package)
-                    print(
-                        "[DEBUG] %s Package install queue size : %s"
-                        % (
-                            datetime.now().strftime("%H:%M:%S"),
-                            len(self.pkg_inst_deque),
-                        )
-                    )
-
                     self.pkg_queue.put(
                         (
                             package,
@@ -458,6 +450,17 @@ class Main(Gtk.Window):
                     )
 
                     th.start()
+                else:
+                    msg_dialog = message_dialog(
+                        self,
+                        "Please wait until previous Pacman transactions are completed",
+                        "There are a maximum of 5 packages added to the queue",
+                        "Waiting for previous Pacman transactions to complete",
+                        Gtk.MessageType.WARNING,
+                    )
+
+                    msg_dialog.run()
+                    msg_dialog.hide()
 
         # switch widget is currently toggled on
         if widget.get_state() == True and widget.get_active() == False:

--- a/usr/share/sofirem/sofirem.py
+++ b/usr/share/sofirem/sofirem.py
@@ -48,8 +48,7 @@ class Main(Gtk.Window):
     # Create a queue to handle package install/removal
     pkg_queue = Queue()
 
-    # A deque to manage the number of packages we can have stacked up
-    # Max = 5
+    # A deque to manage the number of packages to install we can have stacked up
     pkg_inst_deque = deque(maxlen=5)
 
     # Create a queue for storing search results


### PR DESCRIPTION
- Pacman lock file detection to see if the database is locked is now in a separate thread
- Added count on number of packages queued to install, max = 5
- Spamming of package installs will now be restricted, if there is no pacman lock file proceed else show message-box displaying another process is running
- Added pacman process check to show the user which process is currently running inside the message-box
- On closing the app or ctrl +c termination, any pacman processes spawned will be killed
- Popen processes now have a termination call if there is a exception in TimeoutError, SystemError, Exception
- Changed search to ignore string casing
- There is a now a condition to restrict the Pacman lock file thread to run only 1, as this was causing a deadlock in the timeout handling
-  Pacman lock file detection thread will also now check if a Pacman process is running, if there is no process running break out of the loop
- Increased Pacman lock file detection thread to timeout after 5m
-  Increased install/uninstall subprocess to timeout after 2m

Added

- Stop user uninstalling a package whilst installing the same package